### PR TITLE
refactor: make aliases be separate files

### DIFF
--- a/packages/commandapp/src/docs/markdown.ejs
+++ b/packages/commandapp/src/docs/markdown.ejs
@@ -1,5 +1,5 @@
 <% commands.forEach((command) => { %>
-## `<%= command.command %>`
+## `<%= command.command %>`<%= command.alias.map(a => `, \`${a}\``).join('') %>
 
 <%- command.description %>
 

--- a/packages/commandapp/src/docs/markdown.test.js
+++ b/packages/commandapp/src/docs/markdown.test.js
@@ -2,6 +2,7 @@
 import markdownFormatter from './markdown';
 
 const mockCommand = {
+  alias: [],
   description: 'mock command description',
   examples: [{ code: 'this is my example code', description: "this is my example code's description" }],
   command: 'mock-command',

--- a/packages/commandapp/src/docs/stdout.js
+++ b/packages/commandapp/src/docs/stdout.js
@@ -45,7 +45,6 @@ function positionalsTable(positionals: $PropertyType<Command, 'positionals'>): s
 }
 
 export default async function stdoutFormatter(tree: Array<Command> | Command): Promise<string> {
-  const data = { commands: Array.isArray(tree) ? tree : [tree] };
   // $FlowFixMe columns exists on process.stdout
   const { columns = 80 } = process.stdout;
   const columnWidth = Math.floor(columns / 4);
@@ -62,7 +61,10 @@ export default async function stdoutFormatter(tree: Array<Command> | Command): P
     ui.div(
       tree
         .slice(1)
-        .map((command) => `  ${command.command}\t    ${command.description}\n`)
+        .map(
+          (command) =>
+            `  ${command.command}${command.alias.map((a) => `, ${a}`).join('')}\t    ${command.description}\n`
+        )
         .join('')
     );
   }

--- a/packages/commandapp/src/docs/stdout.test.js
+++ b/packages/commandapp/src/docs/stdout.test.js
@@ -2,6 +2,7 @@
 import formatter from './stdout';
 
 const mockCommand = {
+  alias: [],
   description: 'mock command description',
   examples: [{ code: 'this is my example code', description: "this is my example code's description" }],
   command: 'mock-command',

--- a/packages/commandapp/src/logger.js
+++ b/packages/commandapp/src/logger.js
@@ -107,6 +107,10 @@ export default class Logger {
     }
   };
 
+  plain(output: mixed): void {
+    return this.writeStdout(stringify(output));
+  }
+
   log(output: mixed): void {
     return this.writeStdout(stringify(output), [this._chalk.hex('#000').bgCyanBright.bold(' LOG ')]);
   }

--- a/packages/commandapp/src/options.js
+++ b/packages/commandapp/src/options.js
@@ -95,7 +95,7 @@ export type Argv<pos: Positionals, opts: Options> = {|
 export type Examples = Array<{ code: string, description: string }>;
 export type Middleware = (args: {}) => Promise<{}>;
 export type Command = {
-  alias?: string,
+  alias: Array<string>,
   command: string,
   description: string,
   examples: Examples,

--- a/packages/examples/commands/positionals.js
+++ b/packages/examples/commands/positionals.js
@@ -3,8 +3,6 @@ import type { Argv } from '@commandapp/commandapp';
 
 export const description = 'This is the description for the command "foo"';
 
-export const alias = 'pos itional';
-
 export const positionals = {
   'first-positional': {
     description: 'This is a required first positional',

--- a/packages/examples/commands/spawn-processes.js
+++ b/packages/examples/commands/spawn-processes.js
@@ -34,7 +34,6 @@ async function spawnRandomLogs(name: string, logger: Logger, random: typeof genR
       while (logsWritten <= numLogs) {
         await new Promise((resolve) => {
           setTimeout(async () => {
-            // console.log(name, logsWritten);
             let method: typeof childLogger.log = childLogger.log.bind(childLogger);
             const val = random.intBetween(0, 5);
             switch (val) {

--- a/packages/examples/commands/sub/foo.js
+++ b/packages/examples/commands/sub/foo.js
@@ -1,0 +1,18 @@
+// @flow
+import type { Argv } from '@commandapp/commandapp';
+
+export const description = 'This is the description for the command "sub command"';
+
+export const options = {
+  foo: {
+    type: 'string',
+    description: 'This is the description',
+    default: 'foo',
+  },
+};
+
+export const handler = async (argv: Argv<{}, typeof options>) => {
+  const { foo } = argv;
+  console.log('Hello from foo handler' + foo);
+  console.log(argv);
+};

--- a/packages/examples/commands/sub/index.js
+++ b/packages/examples/commands/sub/index.js
@@ -1,20 +1,2 @@
 // @flow
-import type { Argv } from '@commandapp/commandapp';
-
-export const alias = 'foo';
-
-export const description = 'This is the description for the command "sub command"';
-
-export const options = {
-  foo: {
-    type: 'string',
-    description: 'This is the description',
-    default: 'foo',
-  },
-};
-
-export const handler = async (argv: Argv<{}, typeof options>) => {
-  const { foo } = argv;
-  console.log('Hello from foo handler' + foo);
-  console.log(argv);
-};
+export const aliasof = './foo.js';

--- a/packages/examples/run.js
+++ b/packages/examples/run.js
@@ -2,14 +2,16 @@
 // @flow
 const path = require('path');
 
+console.time('startup');
 require('@babel/register')({
   cwd: __dirname,
   rootMode: 'upward',
   ignore: ['node_modules'],
+  // cache: true,
 });
 
 const bootstrap = require('@commandapp/commandapp').default;
-
+console.timeEnd('startup');
 const description = 'My cool example CLI';
 
 bootstrap({ name: 'example', description, rootDir: __dirname, subcommandDir: 'commands' }, {});


### PR DESCRIPTION
## Problem
`@babel/register` really slows down our startup time when we have to `require` every possible command in order to resolve what command will be run. This was originally done in order to accommodate command aliases, as they were in the source file of a command as `export const alias = 'something'`.

## Solution